### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: Continuous Integration
 on: [ pull_request, workflow_dispatch ]
+permissions:
+  contents: read
 jobs:
   unit_test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mdalius/flask-sherlock/security/code-scanning/1](https://github.com/mdalius/flask-sherlock/security/code-scanning/1)

Add an explicit workflow-level `permissions` block in `.github/workflows/ci.yml` directly under `on:` and before `jobs:`:

- `contents: read`

This is the best minimal fix because:
- It satisfies CodeQL’s requirement to explicitly limit `GITHUB_TOKEN`.
- It preserves current behavior (checkout still works).
- It applies consistently to both `unit_test` and `publish` jobs without duplicating config.

No imports, methods, or dependencies are needed; this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
