### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/app/run.py
+++ b/app/run.py
@@ -1,5 +1,6 @@
 import os
 import json
+import logging
 from json.decoder import JSONDecodeError
 
 from flask import Flask
@@ -13,6 +14,7 @@ from rengine import Sherlock
 app = Flask(__name__)
 app.json.ensure_ascii = False
 APP_DIR = os.path.dirname(os.path.realpath(__file__))
+logger = logging.getLogger(__name__)
 
 def read_data(source):
     """
@@ -25,12 +27,15 @@ def read_data(source):
         with open(source) as db:
             content = db.read()
         data = json.loads(content)
-    except FileNotFoundError as e:
-        errors = [f"Reading {source}, {str(e)}"]
-    except JSONDecodeError as e:
-        errors = [f"Reading {source}, {str(e)}"]
-    except Exception as e:
-        errors = [f"Reading {source}, {str(e)}"]
+    except FileNotFoundError:
+        logger.exception("Failed to read data from %s", source)
+        errors = ["Unable to load movie data."]
+    except JSONDecodeError:
+        logger.exception("Failed to parse JSON data from %s", source)
+        errors = ["Unable to load movie data."]
+    except Exception:
+        logger.exception("Unexpected error while reading data from %s", source)
+        errors = ["Unable to load movie data."]
 
     return data, errors
 

--- a/app/test_app.py
+++ b/app/test_app.py
@@ -25,3 +25,16 @@ def test_api(client):
     assert response.status_code == 200
     assert response.is_json
     assert len(response.get_json()) >= 5
+
+
+def test_api_returns_500_when_data_unavailable(client, monkeypatch):
+    monkeypatch.setattr("run.read_data", lambda source: ([], ["Unable to load movie data."]))
+
+    response = client.get("/api/v1/movies/recommend")
+
+    assert response.status_code == 500
+    assert response.is_json
+    assert response.get_json() == {
+        "errors": ["Unable to load movie data."],
+        "status_code": 500,
+    }

--- a/app/test_engine.py
+++ b/app/test_engine.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from run import read_data
+from rengine import Sherlock
+
+
+def test_sherlock_recommend_default_lucky_choice(monkeypatch):
+    movies = [
+        {"title": "Movie A", "genre": ["comedy"], "stars": ["Actor A"], "rating": 5.0},
+        {"title": "Movie B", "genre": ["drama"], "stars": ["Actor B"], "rating": 6.0},
+    ]
+    monkeypatch.setattr("rengine.random.choice", lambda seq: movies[1])
+
+    sherlock = Sherlock(movies, {})
+    recommendation = sherlock.recommend()
+
+    assert recommendation == [movies[1]]
+
+
+def test_sherlock_recommend_matches_genre_and_star():
+    movies = [
+        {"title": "Kingpin", "genre": ["comedy"], "stars": ["Bill Murray"], "rating": 6.9},
+        {"title": "Groundhog Day", "genre": ["comedy"], "stars": ["Bill Murray"], "rating": 8.0},
+        {"title": "Lost in Translation", "genre": ["comedy", "drama"], "stars": ["Scarlett Johansson"], "rating": 7.7},
+        {"title": "Oppenheimer", "genre": ["drama"], "stars": ["Cillian Murphy"], "rating": 8.4},
+    ]
+
+    sherlock = Sherlock(movies, {"title": "Kingpin"})
+    recommendation = sherlock.recommend()
+
+    assert [movie["title"] for movie in recommendation] == ["Groundhog Day", "Lost in Translation"]
+    assert recommendation[0]["rating"] >= recommendation[1]["rating"]
+
+
+def test_read_data_returns_error_for_missing_file():
+    data, errors = read_data("/tmp/nonexistent-movie-db.json")
+
+    assert data == []
+    assert errors == ["Unable to load movie data."]
+
+
+def test_read_data_returns_error_for_invalid_json(tmp_path):
+    bad_file = tmp_path / "invalid.json"
+    bad_file.write_text("{ invalid json }")
+
+    data, errors = read_data(str(bad_file))
+
+    assert data == []
+    assert errors == ["Unable to load movie data."]


### PR DESCRIPTION
Potential fix for [https://github.com/mdalius/flask-sherlock/security/code-scanning/4](https://github.com/mdalius/flask-sherlock/security/code-scanning/4)

To fix this safely without changing endpoint behavior, keep the same control flow and status codes but stop returning raw exception strings to clients.

Best fix in `app/run.py`:
1. Add standard logging (`import logging` and a module logger).
2. In `read_data`, replace each `errors = [f"Reading {source}, {str(e)}"]` with:
   - server-side logging of the exception (`logger.exception(...)`) for diagnostics
   - a generic user-facing message such as `"Unable to load movie data."`
3. Keep the return structure `(data, errors)` unchanged so the rest of the app behavior remains intact and all alert variants (line 28/30/32 exception flows) are addressed in one change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
